### PR TITLE
support server rendering

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -11,9 +11,9 @@ const OutbrainWidget = (props) => {
     obAppVer = '',
     isSecured = '',
   } = props;
-  const { OBR } = window;
 
   useEffect(() => {
+    const { OBR } = window;
     if (OBR && OBR.extern && typeof OBR.extern.renderSpaWidgets === 'function') {
       OBR.extern.renderSpaWidgets(dataSrc);
     }


### PR DESCRIPTION
get OBR in useEffect to make sure it only runs in browser env.

When rending on the server in a nodejs environment the  window variable is not globally available. That makes it so the Component crashes when tried to render on the server. By accesing the window variable in the useEffect hook the code with the window variable runs only on the client