### PR TITLE
Resolve preact rendering issue

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -20,16 +20,18 @@ const OutbrainWidget = (props) => {
   }, [dataSrc]);
 
   return (
-    <div
-      className="OUTBRAIN"
-      data-src={dataSrc}
-      data-widget-id={dataWidgetId}
-      data-ob-template={obTemplate}
-      data-ob-installation-key={obInstallationKey}
-      data-ob-installation-type={obInstallationType}
-      data-ob-app-ver={obAppVer}
-      data-is-secured={isSecured}
-    />
+    <div key={dataWidgetId}>
+      <div
+        className="OUTBRAIN"
+        data-src={dataSrc}
+        data-widget-id={dataWidgetId}
+        data-ob-template={obTemplate}
+        data-ob-installation-key={obInstallationKey}
+        data-ob-installation-type={obInstallationType}
+        data-ob-app-ver={obAppVer}
+        data-is-secured={isSecured}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
When running on preact, we need an additional `div` with a `key` wrapped around the `div` that the outbrain script targets.

This is because DOM diffing is different in preact than react. 

When outbrain inserts content, preact thinks that the `div` that was modified by the script was deleted, and reinserts a duplicate copy. This extra `div` will tell the preact algorithm that nothing has changed here, and there is no need to insert another element in the DOM.