### PR TITLE
Add mandatory field user id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # react-outbrain-widget
-![](https://github.com/outbrain/react-outbrain-widget/blob/master/ob-react.svg
-)
 
-Embed your outbrain widget inside a react app 
+![](https://github.com/outbrain/react-outbrain-widget/blob/master/ob-react.svg)
+
+Embed your outbrain widget inside a react app
 
 [![npm version](https://badge.fury.io/js/react-outbrain-widget.svg)](https://badge.fury.io/js/react-outbrain-widget)
 
@@ -11,7 +11,8 @@ Embed your outbrain widget inside a react app
 [**Live Demo**](https://codesandbox.io/s/54m7mo4o8p)
 
 ## Installation & Usage
-**Note:** *react-outbrain-widget assumes outbrain.js was loaded before react's first rendering. Please make sure outbrain.js is loaded via a script tag on the app's index.html*
+
+**Note:** _react-outbrain-widget assumes outbrain.js was loaded before react's first rendering. Please make sure outbrain.js is loaded via a script tag on the app's index.html_
 
 ```sh
 npm install react-outbrain-widget --save
@@ -20,23 +21,27 @@ npm install react-outbrain-widget --save
 ### Include the Component
 
 ```js
-import React from 'react'
-import { OutbrainWidget } from 'react-outbrain-widget'
+import React from 'react';
+import { OutbrainWidget } from 'react-outbrain-widget';
 
 class Component extends React.Component {
-
   render() {
-    return <OutbrainWidget dataSrc='mySite.com' dataWidgetId='AR_1'/>
+    return (
+      <OutbrainWidget dataSrc="mySite.com" dataWidgetId="AR_1" obUserId="GOOGLE_APPLE_ADVERTISING_ID" obAppVer="X.Y" />
+    );
   }
 }
 ```
+
 ## Props
-Name                   | Type 
------------------------|----------:
-**dataSrc**            |string
-**dataWidgetId**       |string
-**obTemplate**         |string
-**obInstallationKey**  |string
-**obInstallationType** |string
-**obAppVer**           |string
-**isSecured**          |string
+
+| Name                   |   Type |
+| ---------------------- | -----: |
+| **dataSrc**            | string |
+| **dataWidgetId**       | string |
+| **obUserId**           | string |
+| **obTemplate**         | string |
+| **obInstallationKey**  | string |
+| **obInstallationType** | string |
+| **obAppVer**           | string |
+| **isSecured**          | string |

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -5,6 +5,7 @@ const OutbrainWidget = (props) => {
   const {
     dataSrc = '',
     dataWidgetId = '',
+    obUserId = '',
     obTemplate = '',
     obInstallationKey = '',
     obInstallationType = '',
@@ -24,6 +25,7 @@ const OutbrainWidget = (props) => {
       className="OUTBRAIN"
       data-src={dataSrc}
       data-widget-id={dataWidgetId}
+      data-ob-user-id={obUserId}
       data-ob-template={obTemplate}
       data-ob-installation-key={obInstallationKey}
       data-ob-installation-type={obInstallationType}
@@ -36,6 +38,7 @@ const OutbrainWidget = (props) => {
 OutbrainWidget.propTypes = {
   dataSrc: PropTypes.string.isRequired,
   dataWidgetId: PropTypes.string.isRequired,
+  obUserId: PropTypes.string,
   obTemplate: PropTypes.string,
   obInstallationKey: PropTypes.string,
   obInstallationType: PropTypes.string,
@@ -44,6 +47,7 @@ OutbrainWidget.propTypes = {
 };
 
 OutbrainWidget.defaultProps = {
+  obUserId: 'null',
   obTemplate: '',
   obInstallationKey: '',
   obInstallationType: '',


### PR DESCRIPTION
As described [here](https://developer.outbrain.com/using-js-widget-in-mobile-apps/#parameters) now Outbrain requires `user id` as a mandatory field.
With this changes you will be able to add `obUserId` to your component.
As described in the documentation the property `obAppVer` is also mandatory and it is fixed in these changes.